### PR TITLE
Send GlobalContext.Properties and MachineName:ProcessId

### DIFF
--- a/src/Log4netShipper/LogzioAppender.cs
+++ b/src/Log4netShipper/LogzioAppender.cs
@@ -42,7 +42,8 @@ namespace Logzio.DotNet.Log4net
 					{"thread", loggingEvent.ThreadName},
 					{"message", loggingEvent.RenderedMessage},
 					{"exception", loggingEvent.GetExceptionString()},
-					{"user", loggingEvent.UserName},
+					// log4net already adds this 'username' property which is added to values bellow
+					//{"user", loggingEvent.UserName},
 					{"processId", ProcessId}
 				};
 


### PR DESCRIPTION
Possibility to specify (statically and dynamically) fields which should be taken from 'GlobalContext.Properties'.