### PR TITLE
Changes "exception" field name to "exception.Log4net" in order not to…

### DIFF
--- a/src/Log4netShipper/LogzioAppender.cs
+++ b/src/Log4netShipper/LogzioAppender.cs
@@ -53,7 +53,7 @@ namespace Logzio.DotNet.Log4net
                     {"level", loggingEvent.Level.DisplayName},
                     {"thread", loggingEvent.ThreadName},
                     {"message", loggingEvent.RenderedMessage},
-                    {"exception", loggingEvent.GetExceptionString()},
+                    {"exception.Log4Net", loggingEvent.GetExceptionString()},
                     {"processId", ProcessId}
                 };
 


### PR DESCRIPTION
… encounter "illegal_argument_exception" ("reason":"[exception] is defined as a field in mapping [log4net] but this name is already used for an object in other types").