### PR TITLE
Use "name" instead of "key" in nlog

### DIFF
--- a/docs/nlog.md
+++ b/docs/nlog.md
@@ -60,8 +60,8 @@ Any variables defined in the NLog configuration will be forwarded to Logzio. For
 
 ```xml
 	<nlog>
-		<variable key="site" value="New Zealand" />
-		<variable key="rings" value="one" />
+		<variable name="site" value="New Zealand" />
+		<variable name="rings" value="one" />
 	</nlog>
 ```
 


### PR DESCRIPTION
the nlog variable attributes should be "name" and not "key" as per:

https://github.com/NLog/NLog/wiki/Configuration-file#variables