### PR TITLE
Support for custom layout in Nlog target

### DIFF
--- a/src/IntegrationTests/NLog/NLogPerfTests.cs
+++ b/src/IntegrationTests/NLog/NLogPerfTests.cs
@@ -8,6 +8,7 @@ using Logzio.DotNet.IntegrationTests.Listener;
 using Logzio.DotNet.NLog;
 using NLog;
 using NLog.Config;
+using NLog.Layouts;
 using NUnit.Framework;
 
 namespace Logzio.DotNet.IntegrationTests.NLog
@@ -63,6 +64,43 @@ namespace Logzio.DotNet.IntegrationTests.NLog
             LogManager.Shutdown();
 
             _dummy.Requests.Count.ShouldBeEquivalentTo(Math.Ceiling((decimal) (logsAmount / 100)));
+        }
+
+        [Test]
+        public void PerfWithLayout()
+        {
+            var config = new LoggingConfiguration();
+
+            var layout = Layout.FromString("'${shortdate}|${level:uppercase=true}|${message}'");
+            var logzioTarget = new LogzioTarget
+            {
+                Token = "DKJiomZjbFyVvssJDmUAWeEOSNnDARWz",
+                ListenerUrl = LogzioListenerDummy.DefaultUrl,
+                Layout = layout
+            };
+            config.AddTarget("Logzio", logzioTarget);
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, "Logzio", "*");
+            LogManager.Configuration = config;
+
+            var logger = LogManager.GetCurrentClassLogger();
+
+            var stopwatch = Stopwatch.StartNew();
+
+            var logsAmount = 1000;
+            for (var i = 0; i < logsAmount; i++)
+            {
+                logger.Info("A Bird");
+            }
+
+            stopwatch.Stop();
+            Console.WriteLine("Total time: " + stopwatch.Elapsed);
+
+            stopwatch.Elapsed.Should().BeLessOrEqualTo(TimeSpan.FromMilliseconds(100));
+
+            new Bootstraper().Resolve<IShipper>().WaitForSendLogsTask();
+            LogManager.Shutdown();
+
+            _dummy.Requests.Count.ShouldBeEquivalentTo(Math.Ceiling((decimal)(logsAmount / 100)));
         }
     }
 }


### PR DESCRIPTION
Nlog supports a variety of layout renderers (see. https://github.com/nlog/nlog/wiki/Layout-Renderers)
which can be used via the "layout" attribute in the "target" element in Web.config.

Supporting this attribute relies on inheriting from TargetWithLayout and rendering the message
using the layout, if the latter is overridden.