### PR TITLE
Serialize only the LogData-Dictionary and not the entire LogEvent (regression)

### DIFF
--- a/src/Core/Shipping/BulkSender.cs
+++ b/src/Core/Shipping/BulkSender.cs
@@ -72,7 +72,7 @@ namespace Logzio.DotNet.Core.Shipping
                 {
                     if (!firstItem)
                         sw.WriteLine();
-                    _jsonSerializer.Serialize(sw, logEvent);
+                    _jsonSerializer.Serialize(sw, logEvent.LogData);
                     firstItem = false;
                 }
                 return sw.ToString();

--- a/src/IntegrationTests/NLog/NLogSanityTests.cs
+++ b/src/IntegrationTests/NLog/NLogSanityTests.cs
@@ -99,5 +99,28 @@ namespace Logzio.DotNet.IntegrationTests.NLog
             _dummy.Requests.Count.ShouldBe(1);
             _dummy.Requests[0].ShouldContain("threadid");
         }
+
+        [Test]
+        public void SanityWithDuplicateProperty()
+        {
+            var config = new LoggingConfiguration();
+            var logzioTarget = new LogzioTarget
+            {
+                Token = "DKJiomZjbFyVvssJDmUAWeEOSNnDARWz",
+                ListenerUrl = LogzioListenerDummy.DefaultUrl,
+            };
+            config.AddTarget("Logzio", logzioTarget);
+            config.AddRule(LogLevel.Debug, LogLevel.Fatal, "Logzio", "*");
+            LogManager.Configuration = config;
+
+            var logger = LogManager.GetCurrentClassLogger();
+            logger.Info("Received {sequenceId}", 42);
+
+            LogManager.Shutdown();  // Flushes and closes
+
+            _dummy.Requests.Count.ShouldBe(1);
+            _dummy.Requests[0].ShouldContain("sequenceId");
+            _dummy.Requests[0].ShouldContain("sequenceId_1");
+        }
     }
 }

--- a/src/IntegrationTests/Properties/AssemblyInfo.cs
+++ b/src/IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.None)]

--- a/src/NLogShipper/LogzioTarget.cs
+++ b/src/NLogShipper/LogzioTarget.cs
@@ -103,10 +103,18 @@ namespace Logzio.DotNet.NLog
                         if (key.IndexOf(':') != -1)
                             key = key.Replace(':', '_');
 
-                        if (!values.ContainsKey(key))
+                        if (values.ContainsKey(key))
                         {
-                            values[key] = property.Value;
+                            string newKey = string.Concat(key, "_1");
+                            int i = 1;
+                            while (values.ContainsKey(newKey))
+                            {
+                                i++;
+                                newKey = string.Concat(key, "_", i.ToString("d"));
+                            }
+                            key = newKey;
                         }
+                        values[key] = property.Value;
                     }
                 }
                 else if (ContextProperties.Count > 0)

--- a/src/UnitTests/Properties/AssemblyInfo.cs
+++ b/src/UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.None)]

--- a/src/UnitTests/Shipping/BulkSenderTests.cs
+++ b/src/UnitTests/Shipping/BulkSenderTests.cs
@@ -27,10 +27,11 @@ namespace Logzio.DotNet.UnitTests.Shipping
         [Test]
         public void SendAsync_Logs_LogsAreSent()
         {
-            _target.SendAsync(new[] { GetLoggingEventWithSomeData(), GetLoggingEventWithSomeData() }, new BulkSenderOptions()).Wait();
-
-            _webClientFactory.Received().GetWebClient();
-            _webClient.Received().UploadString(Arg.Any<string>(), Arg.Any<string>());
+            var log = GetLoggingEventWithSomeData();
+            log.LogData.Remove("@timestamp");
+            _target.SendAsync(new[] { log }, new BulkSenderOptions()).Wait();
+            _webClient.Received()
+                .UploadString(Arg.Any<string>(), Arg.Is<string>(x => x.Equals("{\"message\":\"hey\"}")));
         }
 
         [Test]

--- a/src/UnitTests/Shipping/ShipperTests.cs
+++ b/src/UnitTests/Shipping/ShipperTests.cs
@@ -78,7 +78,7 @@ namespace Logzio.DotNet.UnitTests.Shipping
             var options = new ShipperOptions
             {
                 BufferSize = 10,
-                BufferTimeLimit = TimeSpan.FromMilliseconds(20)
+                BufferTimeLimit = TimeSpan.FromMilliseconds(50)
             };
 
             _target.Ship(GetLoggingEventWithSomeData(), options);
@@ -87,7 +87,7 @@ namespace Logzio.DotNet.UnitTests.Shipping
 
             _bulkSender.DidNotReceiveWithAnyArgs().Send(Arg.Any<ICollection<LogzioLoggingEvent>>(), Arg.Any<BulkSenderOptions>());
 
-            Thread.Sleep(TimeSpan.FromMilliseconds(30)); //wait for the actual timeout // Measured timing based instability. Hard to reproduce.
+            Thread.Sleep(TimeSpan.FromMilliseconds(100)); //wait for the actual timeout // Measured timing based instability. Hard to reproduce.
             _bulkSender.Received().Send(Arg.Is<ICollection<LogzioLoggingEvent>>(x => x.Count == 2), Arg.Any<BulkSenderOptions>());
         }
 


### PR DESCRIPTION
Resolves #20, by fixing bug introduced with #16 (Modified unit test to avoid this regression in the future)