### PR TITLE
Added: net5.0 target to all projects

### DIFF
--- a/package/build.ps1
+++ b/package/build.ps1
@@ -3,4 +3,4 @@ param (
     [string]$Version
 )
 
-msbuild /t:Restore,Pack $ProjectName /p:Version=$Version /p:targetFrameworks='"net45;netstandard2.0;netstandard1.3"' /p:Configuration=Release /p:PackageOutputPath=..\..\package /verbosity:minimal
+msbuild /t:Restore,Pack $ProjectName /p:Version=$Version /p:targetFrameworks='"net5.0;netstandard2.0;"' /p:Configuration=Release /p:PackageOutputPath=..\..\package /verbosity:minimal

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     
-    <TargetFrameworks Condition=" ' $(TargetFrameworks) ' == '  ' ">netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" ' $(TargetFrameworks) ' == '  ' ">netstandard2.0;netstandard1.3;net5.0</TargetFrameworks>
 
     <AssemblyName>Logzio.DotNet.Core</AssemblyName>
     <Company>Logz.io</Company>

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0-preview-20171211-02" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -3,9 +3,9 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Log4netShipper/Log4netShipper.csproj
+++ b/src/Log4netShipper/Log4netShipper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netstandard2.0;netstandard1.3;net5.0</TargetFrameworks>
 
     <AssemblyName>Logzio.DotNet.Log4net</AssemblyName>
 

--- a/src/Log4netShipper/Log4netShipper.csproj
+++ b/src/Log4netShipper/Log4netShipper.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.12" />
     <!-- Newtonsoft.Json MUST be here for correct nuget-package generation -->
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLogShipper/NLogShipper.csproj
+++ b/src/NLogShipper/NLogShipper.csproj
@@ -31,7 +31,7 @@
       $(TargetsForTfmSpecificBuildOutput);PackReferencedProjectOutputs
     </TargetsForTfmSpecificBuildOutput>
     <PackageId>Logzio.NLog.NET5</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Product>Logzio.NLog.NET5</Product>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/NLogShipper/NLogShipper.csproj
+++ b/src/NLogShipper/NLogShipper.csproj
@@ -10,16 +10,16 @@
     <CurrentYear>$([System.DateTime]::Now.ToString(yyyy))</CurrentYear>
     <Copyright>Copyright (c) $(CurrentYear) - Logz.io</Copyright>
     <PackageTags>logging;log;logzio;nlog</PackageTags>
-    <PackageProjectUrl>https://github.com/logzio/logzio-dotnet</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/jcapellman/logzio-dotnet</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/logzio/logzio-dotnet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/jcapellman/logzio-dotnet</RepositoryUrl>
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="NLog" Version="4.7.10" />
     <!-- Newtonsoft.Json MUST be here for correct nuget-package generation -->
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
  
   <ItemGroup>
@@ -30,6 +30,10 @@
     <TargetsForTfmSpecificBuildOutput>
       $(TargetsForTfmSpecificBuildOutput);PackReferencedProjectOutputs
     </TargetsForTfmSpecificBuildOutput>
+    <PackageId>Logzio.NLog.NET5</PackageId>
+    <Version>1.3.0</Version>
+    <Product>Logzio.NLog.NET5</Product>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
  
   <Target Name="PackReferencedProjectOutputs" DependsOnTargets="BuildOnlySettings;ResolveReferences">

--- a/src/NLogShipper/NLogShipper.csproj
+++ b/src/NLogShipper/NLogShipper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">netstandard2.0;netstandard1.3;net5.0</TargetFrameworks>
 
     <AssemblyName>Logzio.DotNet.NLog</AssemblyName>
     

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -3,11 +3,11 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Shouldly" Version="3.0.0-beta0003" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Given all of my legacy .NET Core 3.x projects are migrating to .NET 5 and any new project is utilizing .NET 5 I added build targets for .NET 5