### PR TITLE
Support `net8.0` 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,29 @@
 name: build and release a new package version
+
 on: 
   release:
     types: [published]
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
       - name: Setup .NET 8.x
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
+      
       - name: Install dependencies
         working-directory: ./src
         run: dotnet restore logzio-dotnet.sln
+      
       - name: Build and release package
         working-directory: ./src
         run: |
+          dotnet publish -c Release -f net8.0
           dotnet publish -c Release -f net6.0
-          dotnet pack --configuration Release
+          dotnet pack --configuration Release -p:TargetFrameworks="net8.0;net6.0"
           dotnet nuget push "./Log4netShipper/bin/Release/Logzio.DotNet.Log4net.${{ github.event.release.tag_name }}.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
           dotnet nuget push "./NLogShipper/bin/Release/Logzio.DotNet.NLog.${{ github.event.release.tag_name }}.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,15 +6,12 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['2.0', '3.0', '5.0', '6.0', '7.0', '8.0']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET ${{ matrix.dotnet-version }}
+      - name: Setup .NET 8.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: 8.0
       - name: Display dotnet version
         run: dotnet --version
       - name: Install dependencies

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
 
     <AssemblyName>Logzio.DotNet.Core</AssemblyName>
@@ -13,7 +13,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/Log4netShipper/Log4netShipper.csproj
+++ b/src/Log4netShipper/Log4netShipper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0;net8.0</TargetFrameworks>
 
     <AssemblyName>Logzio.DotNet.Log4net</AssemblyName>
 
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/logzio/logzio-dotnet</RepositoryUrl>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <PackageReleaseNotes>Option to format message as json</PackageReleaseNotes>
     <PackageReadmeFile>log4net.md</PackageReadmeFile>
   </PropertyGroup>
@@ -41,6 +41,10 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLogShipper/NLogShipper.csproj
+++ b/src/NLogShipper/NLogShipper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TargetFrameworks)' == '' ">net5.0;netcoreapp3.1;netstandard1.3;netstandard2.0;net6.0;net8.0</TargetFrameworks>
 
     <AssemblyName>Logzio.DotNet.NLog</AssemblyName>
     
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/logzio/logzio-dotnet</RepositoryUrl>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <PackageReleaseNotes>Option to format message as json</PackageReleaseNotes>
     <PackageReadmeFile>nlog.md</PackageReadmeFile>
   </PropertyGroup>
@@ -28,7 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" PrivateAssets="all" />
   </ItemGroup>
- 
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="OpenTelemetry" Version="1.3.1" />
   </ItemGroup>
@@ -42,6 +42,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0;net8.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />


### PR DESCRIPTION
Following customer issues this PR adds support for `net8.0` opentelemetry dependencies