### PR TITLE
Release 1.2.2 preparation

### DIFF
--- a/src/Log4netShipper/Log4netShipper.csproj
+++ b/src/Log4netShipper/Log4netShipper.csproj
@@ -17,8 +17,8 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/logzio/logzio-dotnet</RepositoryUrl>
-    <PackageVersion>1.2.1</PackageVersion>
-    <PackageReleaseNotes>Fix InvalidCastException when running against log4net 3.x — appender now iterates LoggingEvent properties via GetKeys() instead of foreach (DictionaryEntry ...).</PackageReleaseNotes>
+    <PackageVersion>1.2.2</PackageVersion>
+    <PackageReleaseNotes>Fix InvalidCastException when running against log4net 3.x — appender now iterates LoggingEvent properties via GetKeys() instead of foreach (DictionaryEntry ...). (Re-published from 1.2.1, which never reached NuGet.)</PackageReleaseNotes>
     <PackageReadmeFile>log4net.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/NLogShipper/NLogShipper.csproj
+++ b/src/NLogShipper/NLogShipper.csproj
@@ -14,8 +14,8 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/logzio/logzio-dotnet</RepositoryUrl>
-    <PackageVersion>1.2.1</PackageVersion>
-    <PackageReleaseNotes>No functional changes — released alongside Logzio.DotNet.Log4net 1.2.1.</PackageReleaseNotes>
+    <PackageVersion>1.2.2</PackageVersion>
+    <PackageReleaseNotes>No functional changes — released alongside Logzio.DotNet.Log4net 1.2.2.</PackageReleaseNotes>
     <PackageReadmeFile>nlog.md</PackageReadmeFile>
   </PropertyGroup>
  


### PR DESCRIPTION
## Description 

Release 1.2.1 never reached nuget, 1.2.2 includes fix for log4net 3.x and also removes the conflict with partially released 1.2.1.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
